### PR TITLE
chore: remove vue-template-compiler

### DIFF
--- a/generator/index.js
+++ b/generator/index.js
@@ -4,11 +4,14 @@ module.exports = (api) => {
       vue: '^3.0.0-alpha.4'
     },
     devDependencies: {
-      '@vue/compiler-sfc': '^3.0.0-alpha.4'
+      '@vue/compiler-sfc': '^3.0.0-alpha.4',
+      // remove the vue-template-compiler
+      'vue-template-compiler': null
     }
+  },
+  {
+    prune: true
   })
 
   api.transformScript(api.entryFile, require('./codemods/rfc09-global-api'))
-
-  // TODO: uninstall vue-template-compiler (need to fix @vue/cli-service first)
 }


### PR DESCRIPTION
When https://github.com/vuejs/vue-cli/pull/5170 lands in the CLI, we should be able to remove `vue-template-compiler` from the devDependencies.

Fixes #5